### PR TITLE
npm-friendly package.json name field value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Front-end boilerplate",
+  "name": "front-end-boilerplate",
   "private": true,
   "version": "1.0.0",
   "description": "",


### PR DESCRIPTION
Was getting `npm WARN Invalid name: "Front-end boilerplate"` with previous value
